### PR TITLE
fixing lazy component

### DIFF
--- a/src/components/beagle-lazy/beagle-lazy.component.ts
+++ b/src/components/beagle-lazy/beagle-lazy.component.ts
@@ -38,7 +38,11 @@ export class BeagleLazyComponent extends BeagleComponent implements BeagleLazyIn
       shouldShowLoading: false,
     }
 
-    this.getViewContentManager().replaceComponent(params)
+    this.getViewContentManager().getView().fetch(
+      params,
+      this.getViewContentManager().getElementId(),
+      'replaceComponent',
+    )
   }
 
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Depends on https://github.com/ZupIT/beagle-web-core/pull/234

Removes the usage of `replaceComponent` in the LazyComponent. This shortcut method doesn't exist anymore. The reasons are explained in https://github.com/ZupIT/beagle-web-core/pull/234.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
