### PR TITLE
Fixes getViewContentManager error

### DIFF
--- a/src/codegen/utils/template-builder.ts
+++ b/src/codegen/utils/template-builder.ts
@@ -29,21 +29,22 @@ function kebabToCamelCase(str: string) {
 
 function createTemplateForComponent(selector: string, inputs: ComponentFactory<any>['inputs']) {
   const templateName = kebabToCamelCase(selector)
-  const templateInputs = inputs.map(input => 
+  const templateInputs = inputs.map(input =>
     `let-${input.propName}="tree.${input.propName}"`).join(' ')
   const componentInputs = inputs.map(input =>
     `[${input.templateName}]="${input.propName}"`).join(' ')
   const contextDirective = `${viewContentManagerSelector} [_elementId]="beagleId" [_viewId]="viewId"`
   const addStyleId = inputs.findIndex((item) => item.propName === 'styleId')
   const styleIdVariable = addStyleId >= 0 ? '' : 'let-styleId="tree.styleId"'
-  
+
   const addStyle = inputs.findIndex((item) => item.propName === 'style')
   const styleVariable = addStyle >= 0 ? '' : 'let-style="tree.style"'
 
   return `
     <ng-template #${templateName} ${templateInputs} ${styleIdVariable} let-children="tree.children"
       let-beagleId="tree.id" ${styleVariable}>
-      <${selector} ${componentInputs} ${contextDirective} [attr.data-beagle-id]="beagleId"
+      <${selector} ${componentInputs} ${contextDirective} [attr.data-beagle-id]="beagleId" 
+      #self [selfReference]="self"
         [ngClass]="styleId || ''" [ngStyle]="style">
         <ng-container *ngFor="let child of children; trackBy: elementIdentity">
           <ng-container 

--- a/src/codegen/utils/template-builder.ts
+++ b/src/codegen/utils/template-builder.ts
@@ -33,7 +33,8 @@ function createTemplateForComponent(selector: string, inputs: ComponentFactory<a
     `let-${input.propName}="tree.${input.propName}"`).join(' ')
   const componentInputs = inputs.map(input =>
     `[${input.templateName}]="${input.propName}"`).join(' ')
-  const contextDirective = `${viewContentManagerSelector} [_elementId]="beagleId" [_viewId]="viewId"`
+  const contextDirective = `${viewContentManagerSelector} [_elementId]="beagleId" [_viewId]="viewId"
+  #self [_selfReference]="self"`
   const addStyleId = inputs.findIndex((item) => item.propName === 'styleId')
   const styleIdVariable = addStyleId >= 0 ? '' : 'let-styleId="tree.styleId"'
 
@@ -44,7 +45,6 @@ function createTemplateForComponent(selector: string, inputs: ComponentFactory<a
     <ng-template #${templateName} ${templateInputs} ${styleIdVariable} let-children="tree.children"
       let-beagleId="tree.id" ${styleVariable}>
       <${selector} ${componentInputs} ${contextDirective} [attr.data-beagle-id]="beagleId" 
-      #self [selfReference]="self"
         [ngClass]="styleId || ''" [ngStyle]="style">
         <ng-container *ngFor="let child of children; trackBy: elementIdentity">
           <ng-container 

--- a/src/runtime/view-content-manager/directive.ts
+++ b/src/runtime/view-content-manager/directive.ts
@@ -14,7 +14,7 @@
   * limitations under the License.
 */
 
-import { Directive, ViewContainerRef, ElementRef, OnInit, Input } from '@angular/core'
+import { Directive, ViewContainerRef, ElementRef, OnInit, Input, Component } from '@angular/core'
 import { logger, ViewContentManagerMap } from '@zup-it/beagle-web'
 import { createBeagleContextFromViewContentManager } from '@zup-it/beagle-web/legacy/beagle-context'
 import { viewContentManagerSelector } from '../../constants'
@@ -27,6 +27,7 @@ import { BeagleComponent } from '../BeagleComponent'
 export class ViewContentManager implements OnInit {
   @Input() _elementId: string
   @Input() _viewId: string
+  @Input() selfReference: any
   private contentManagerMap: ViewContentManagerMap
 
   constructor(
@@ -39,19 +40,10 @@ export class ViewContentManager implements OnInit {
     this.contentManagerMap = beagleService.viewContentManagerMap
   }
 
-  ngOnInit() {
-    let component
 
-    // @ts-ignore
-    if (ng && typeof (ng.getComponent) === 'function') {
-      //IVY provides ng.getComponent function whereas other versions don't
-      // @ts-ignore
-      component = ng.getComponent(this.elementRef.nativeElement)
-    } else {
-      
-      // @ts-ignore
-      component = this.viewContainerRef._data?.componentView?.component
-    }
+  ngOnInit() {
+    const component = this.selfReference
+
     if (component instanceof BeagleComponent) {
       component.getViewContentManager = () => (
         this.contentManagerMap.get(this._viewId, this._elementId)

--- a/src/runtime/view-content-manager/directive.ts
+++ b/src/runtime/view-content-manager/directive.ts
@@ -14,7 +14,7 @@
   * limitations under the License.
 */
 
-import { Directive, ViewContainerRef, ElementRef, OnInit, Input, Component } from '@angular/core'
+import { Directive, ViewContainerRef, ElementRef, OnInit, Input } from '@angular/core'
 import { logger, ViewContentManagerMap } from '@zup-it/beagle-web'
 import { createBeagleContextFromViewContentManager } from '@zup-it/beagle-web/legacy/beagle-context'
 import { viewContentManagerSelector } from '../../constants'
@@ -27,7 +27,7 @@ import { BeagleComponent } from '../BeagleComponent'
 export class ViewContentManager implements OnInit {
   @Input() _elementId: string
   @Input() _viewId: string
-  @Input() selfReference: any
+  @Input() _selfReference: any
   private contentManagerMap: ViewContentManagerMap
 
   constructor(
@@ -42,8 +42,8 @@ export class ViewContentManager implements OnInit {
 
 
   ngOnInit() {
-    const component = this.selfReference
-
+    const component = this._selfReference
+    
     if (component instanceof BeagleComponent) {
       component.getViewContentManager = () => (
         this.contentManagerMap.get(this._viewId, this._elementId)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-angular/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
closes #197 

**- What I did**
Fixed error that caused the application to crash when using Ivy due to an undefined reference to the function getViewContentManager. I left documented on the issue(#197 ) some other approaches I have tried before finding this solution

**- How I did it**
Removed old reference to 'ng' which is an angular utils that should only be used in development mode
Added to the generate template an Input and an Id to reference itself, Those can then be accessed from the directive.

To test the solution I created an angular application and ran it with both Ivy enabled and disabled, I also tested with the project beagle forms for angular and finally  using a branch from the mfi project. All of them were built, executed and rendered without further problems 

**- How to verify it**
Use this branch in a project which has Ivy enabled


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
