### PR TITLE
Add the style white-space: pre-wrap to the beagle-text.

### DIFF
--- a/src/components/beagle-text/beagle-text.component.less
+++ b/src/components/beagle-text/beagle-text.component.less
@@ -21,6 +21,6 @@ beagle-text {
     margin: 0;
     background-color: inherit;
     border-radius: inherit;
-    white-space: pre;
+    white-space: pre-wrap;
   }
 }


### PR DESCRIPTION
- What I did

I added the white space style: pre-wrap to the beagle-text.

- How I did it

I added the white space style: pre-wrap, in the text component

- How to verify it

\n and \t will be interpreted as a space instead of a line break or a tab.

- Description for the changelog

The text components (Angular and React) behave similarly to the cell phone

closes: ZupIT/beagle-web-core#274