### PR TITLE
Fix/text overflow wrap

### DIFF
--- a/src/components/beagle-text/beagle-text.component.html
+++ b/src/components/beagle-text/beagle-text.component.html
@@ -14,6 +14,5 @@
   * limitations under the License. 
 -->
 
-<p class='beagle-text' [ngStyle]="{color: textColor, 'text-align': alignment && alignment.toLowerCase()}">
-  {{text}}
-</p>
+<!-- it is important that there's no space between the end of the "p" tag and the text -->
+<p class='beagle-text' [ngStyle]="{color: textColor, 'text-align': alignment && alignment.toLowerCase()}">{{text}}</p>

--- a/src/components/beagle-text/beagle-text.component.less
+++ b/src/components/beagle-text/beagle-text.component.less
@@ -22,5 +22,6 @@ beagle-text {
     background-color: inherit;
     border-radius: inherit;
     white-space: pre-wrap;
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-react/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
- Fixed problem where text without spaces would overflow the parent container instead of breaking.
- Fixed another problem where an annoying whitespace character would be added before the text. See an example [here](https://playground.usebeagle.io/#/cloud/95e483e0ca1247e2aba3e66a458afdcb?platform=angular). Change to react to see no white space is added.

**- How I did it**
- Added the css property `overflow-wrap: word-break;`.
- Put the text and the tag `p` in the same line to remove the unwanted white space.

**- How to verify it**
Playground and Landing Page. See the screenshots below:

![landingPage](https://i.ibb.co/nmmRfLf/Captura-de-Tela-2020-11-26-a-s-12-13-37.png)
![playground-react](https://i.ibb.co/dWx79z0/Captura-de-Tela-2020-11-26-a-s-12-16-36.png)
![playground-angular](https://i.ibb.co/gWHBfWH/Captura-de-Tela-2020-11-26-a-s-12-41-54.png)

**- Description for the changelog**
- Fixes problem where text would not break when overflowing its parent.
- Fixed problem where an annoying whitespace character would be added before the text.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
