### PR TITLE
remove relative path of lazy component

### DIFF
--- a/src/components/beagle-lazy/beagle-lazy.component.ts
+++ b/src/components/beagle-lazy/beagle-lazy.component.ts
@@ -33,10 +33,6 @@ export class BeagleLazyComponent extends BeagleComponent implements BeagleLazyIn
     super()
   }
 
-  private getRelativePath() {
-    return this.path.replace(/^([^\/])/, '/$1')
-  }
-
   private replaceChildren(tree: BeagleUIElement) {
     const beagleView = this.getViewContentManager().getView()
     const anchor = this.getViewContentManager().getElementId()
@@ -48,7 +44,7 @@ export class BeagleLazyComponent extends BeagleComponent implements BeagleLazyIn
     advantage of the cache system provided by Beagle */
     const beagleView = this.getViewContentManager().getView()
     const { urlBuilder, viewClient } = beagleView.getBeagleService()
-    const url = urlBuilder.build(this.getRelativePath())
+    const url = urlBuilder.build(this.path)
     viewClient.load({
       url,
       onChangeTree: tree => this.replaceChildren(tree),


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-angular/blob/master/CONTRIBUTING.md

Please provide the following information:
-->
closes https://github.com/ZupIT/beagle-web-core/issues/316
**- What I did**
I removed the function that made the lazy component patch always reactive to url 

**- How I did it**
Removing the geRelativePath function
 
**- How to verify it**
Was tested using an angular poc 

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
