### PR TITLE
fix enable field bug

### DIFF
--- a/src/__tests__/components/__snapshots__/beagle-button.spec.ts.snap
+++ b/src/__tests__/components/__snapshots__/beagle-button.spec.ts.snap
@@ -2,13 +2,11 @@
 
 exports[`BeagleButtonComponent should match snapshot 1`] = `
 <beagle-button
-  disabled="false"
   getViewContentManager={[Function Function]}
   type={[Function String]}
   usefulStyle={[Function Object]}
 >
   <button
-    aria-disabled="false"
     type="button"
   >
      

--- a/src/components/beagle-button/beagle-button.component.ts
+++ b/src/components/beagle-button/beagle-button.component.ts
@@ -48,6 +48,9 @@ export class BeagleButtonComponent extends BeagleComponent
         return styleObject
       }, {})
     }
+  }
+
+  ngOnChanges() {
     this.disabled = this.enabled === undefined ? false : !this.enabled
   }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-angular/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Corrected the behavior that adapted with the button to be disabled.

**- How I did it**
The bug happened because the value in `this.disabled` was loaded before the rendering of the beagle ended.

**- How to verify it**
It was verified through an angular poc.

**- Description for the changelog**
Closes #249
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
