### PR TITLE
Adds new way to calc grid column

### DIFF
--- a/src/components/dynamic-lists/dynamic-list.component.ts
+++ b/src/components/dynamic-lists/dynamic-list.component.ts
@@ -92,8 +92,7 @@ export class DynamicListComponent
   }
 
   getColumnsQuantityStyle() {
-    const screenSize = document.body.clientWidth
-    return this.numColumns && `repeat(${this.numColumns}, ${screenSize/this.numColumns}px)`
+    return this.numColumns && `repeat(${this.numColumns}, 1fr)`
   }
 
   getClassForType() {

--- a/src/components/dynamic-lists/dynamic-list.component.ts
+++ b/src/components/dynamic-lists/dynamic-list.component.ts
@@ -92,7 +92,8 @@ export class DynamicListComponent
   }
 
   getColumnsQuantityStyle() {
-    return `repeat(${this.numColumns}, auto)`
+    const screenSize = document.body.clientWidth
+    return this.numColumns && `repeat(${this.numColumns}, ${screenSize/this.numColumns}px)`
   }
 
   getClassForType() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/beagle-web-angular/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
Changed the way the column size is calculated in grid components
**- How I did it**
Instead of value 'auto' , got the size from the screen size and number of columns
**- How to verify it**
Use the new grid component and check its size in the inspect tools of your browser
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
