### PR TITLE
Fix: DynamicLists - componentManager was wrongly giving ids and suffixes to components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zup-it/beagle-angular",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "license": "Apache-2.0",
   "licenses": [
     {

--- a/src/components/dynamic-lists/dynamic-list.component.ts
+++ b/src/components/dynamic-lists/dynamic-list.component.ts
@@ -30,6 +30,7 @@ import {
   logger, 
   TemplateManager, 
   TemplateManagerItem,
+  Tree,
 } from '@zup-it/beagle-web'
 import { BeagleComponent } from '../../runtime/BeagleComponent'
 import { ListDirection, DynamicListInterface, ListType } from '../schemas/dynamic-list'
@@ -173,17 +174,20 @@ export class DynamicListComponent
       templates: manageableTemplates,
     }
     const componentManager = (component: IdentifiableBeagleUIElement, index: number) => {
-      const iterationKey = this.key && this.dataSource[index][this.key] 
+      Tree.forEach(component, (treeComponent, componentIndex) => {
+        const iterationKey = this.key && this.dataSource[index][this.key] 
         ? this.dataSource[index][this.key] 
         : index
-      const baseId = component.id ? `${component.id}${suffix}` : `${element.id}:${index}`
-      const hasSuffix = ['beagle:listview', 'beagle:gridview'].includes(componentTag)
-      return {
-        ...component,
-        id: `${baseId}:${iterationKey}`,
-        key: this.getIteratorName(),
-        ...(hasSuffix ? { __suffix__: `${suffix}:${iterationKey}` } : {}),
-      }
+        const baseId = treeComponent.id 
+          ? `${treeComponent.id}${suffix}` 
+          : `${element.id}:${componentIndex}`
+        const hasSuffix = ['beagle:listview', 'beagle:gridview'].includes(componentTag)
+        treeComponent.id = `${baseId}:${iterationKey}`
+        if (hasSuffix) {
+          treeComponent.__suffix__ = `${suffix}:${iterationKey}`
+        }
+      })
+      return component
     }
     const contexts: DataContext[][] = this.dataSource
       .map(item => [{ id: this.getIteratorName(), value: item }])


### PR DESCRIPTION
**- What I did**
Fixed how the `componentManager` was handling ids and components for children.

**- How I did it**
Brought back the behavior using the `Tree` and looping on each children of the new component, attributing the right ids and suffixes.

**- How to verify it**
Create a `DynamicList` where it has as children elements with ids (especially with `listview` and `gridview`)

Closes #275 